### PR TITLE
Fix typo in renderToImage comment

### DIFF
--- a/src/logic/renderToImage.ts
+++ b/src/logic/renderToImage.ts
@@ -1,6 +1,6 @@
 /*
- * Render given url as an HTMLImageEmenet.
- * resolves to null if loading fails.
+ * Render given URL as an HTMLImageElement.
+ * Resolves to null if loading fails.
  */
 export function renderToImage(
   imageUrl: string,


### PR DESCRIPTION
## Summary
- improve grammar in renderToImage comment

## Testing
- `pnpm test` *(fails: Error when performing the request)*

------
https://chatgpt.com/codex/tasks/task_e_6843ea4fe53c83299ee00f6b47e4b982